### PR TITLE
Fix the wrong path for setup-data.

### DIFF
--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -25,7 +25,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "setup-data": "mkdir -p src/data && cp ../analyze/output/* src/data"
+    "setup-data": "mkdir -p src/data && cp ../../analyze/output/* src/data"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Hi, I tried to visualize but it didn't work. I've noticed that the  specified directory path as src must be one more upper, then it works well. Could you confirm it?

```
❯ pwd
/Users/krouton/git-count-commits

❯ make visualize -B repository_path=<my-project>
REACT_APP_REPOSITORY_PATH=<my-project> yarn visualize
yarn run v1.22.4
$ yarn workspace visualize setup-data && yarn workspace visualize start
$ mkdir -p src/data && cp ../analyze/output/* src/data
cp: ../analyze/output/*: No such file or directory
```